### PR TITLE
Updated ruby versions in test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,12 @@ jobs:
           - 3.2
           - 3.1
           - 3.0
-          - 2.7
         gemfile:
           - Gemfile-rails-7
           - Gemfile-rails-6.1
-          - Gemfile-rails-6.0
+        include:
+          - ruby-version: 2.7
+            gemfile: Gemfile-rails-6.0
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}
@@ -36,4 +37,5 @@ jobs:
           BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}
         run: |
           bundle
+          bundle exec rake db:migrate RAILS_ENV=test
           bundle exec rake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,24 +12,18 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - 3.2
+          - 3.1
           - 3.0
           - 2.7
-          - 2.6
-          - 2.5
         gemfile:
           - Gemfile-rails-7
           - Gemfile-rails-6.1
           - Gemfile-rails-6.0
-        exclude:
-          # Rails 7 requires Ruby 2.7+
-          - ruby-version: 2.5
-            gemfile: Gemfile-rails-7
-          - ruby-version: 2.6
-            gemfile: Gemfile-rails-7
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Run gem tests

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in devise-passwordless.gemspec
 gemspec
 
-gem "rake", "~> 10.0"
+gem "rake", "~> 13.0"
 
 group :test do
   gem "rspec", "~> 3.0"

--- a/devise-passwordless.gemspec
+++ b/devise-passwordless.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.1.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.add_dependency "devise"
 end

--- a/spec/dummy_app/spec/rails_helper.rb
+++ b/spec/dummy_app/spec/rails_helper.rb
@@ -27,12 +27,12 @@ Capybara.server = :webrick
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
-begin
-  ActiveRecord::Migration.maintain_test_schema!
-rescue ActiveRecord::PendingMigrationError => e
-  puts e.to_s.strip
-  exit 1
-end
+# begin
+#   ActiveRecord::Migration.maintain_test_schema!
+# rescue ActiveRecord::PendingMigrationError => e
+#   puts e.to_s.strip
+#   exit 1
+# end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
Github actions fails on ruby 2.5 every time because of a bundler error:

    The last version of bundler (~> 2) to support your Ruby & RubyGems was 2.3.26. Try installing it with `gem install bundler -v 2.3.26`
    bundler requires Ruby version >= 2.6.0. The current ruby version is 2.5.0.

Ruby 2.5 was EOL two years ago, so I've removed it and also Ruby 2.6 (which was EOL a year ago). I've also added ruby 3.1 and 3.2 (which were missing entirely)