### PR TITLE
Soft-fail if no token is provided

### DIFF
--- a/lib/devise/strategies/magic_link_authenticatable.rb
+++ b/lib/devise/strategies/magic_link_authenticatable.rb
@@ -20,6 +20,11 @@ module Devise
       end
 
       def authenticate!
+        unless self.token.present?
+          fail(:magic_link_invalid)
+          return
+        end
+
         begin
           data = decode_passwordless_token
         rescue Devise::Passwordless::LoginToken::InvalidOrExpiredTokenError

--- a/spec/devise/strategies/magic_link_authenticatable_spec.rb
+++ b/spec/devise/strategies/magic_link_authenticatable_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+RSpec::Matchers.define_negated_matcher :avoid_changing, :change
+
+RSpec.describe Devise::Strategies::MagicLinkAuthenticatable do
+  describe "#authenticate!" do
+    let(:strategy) { described_class.new(env) }
+    let(:env) { env_with_params }
+    context "when no token is provided" do
+      let(:request_token) { nil }
+      it "soft fails" do
+        strategy.token = nil
+
+        expect {
+          strategy.authenticate!
+        }.to change { strategy.result }.to(:failure)
+         .and avoid_changing { strategy.halted? }
+      end
+    end
+  end
+end
+
+def env_with_params(path = "/", params = {}, env = {})
+  method = params.delete(:method) || "GET"
+  env = { 'HTTP_VERSION' => '1.1', 'REQUEST_METHOD' => "#{method}" }.merge(env)
+  Rack::MockRequest.env_for("#{path}?#{Rack::Utils.build_query(params)}", env)
+end


### PR DESCRIPTION
In order to coexist with other authentication strategies (i.e. fallback to password authentication), add a check for token existence and soft-fail if no token is provided.