### PR TITLE
Add path option to token

### DIFF
--- a/lib/devise/models/magic_link_authenticatable.rb
+++ b/lib/devise/models/magic_link_authenticatable.rb
@@ -15,7 +15,7 @@ module Devise
       end
 
       def send_magic_link(remember_me, opts = {})
-        token = Devise::Passwordless::LoginToken.encode(self)
+        token = Devise::Passwordless::LoginToken.encode(self, path: opts[:path])
         send_devise_notification(:magic_link, token, remember_me, opts)
       end
 
@@ -29,7 +29,7 @@ module Devise
       #     self.update_attribute(:invite_code, nil)
       #   end
       #
-      def after_magic_link_authentication
+      def after_magic_link_authentication(_token_data)
       end
 
       protected

--- a/lib/devise/passwordless/login_token.rb
+++ b/lib/devise/passwordless/login_token.rb
@@ -2,7 +2,7 @@ module Devise::Passwordless
   class LoginToken
     class InvalidOrExpiredTokenError < StandardError; end
 
-    def self.encode(resource)
+    def self.encode(resource, opts = {})
       now = Time.current
       len = ActiveSupport::MessageEncryptor.key_len
       salt = SecureRandom.random_bytes(len)
@@ -14,6 +14,7 @@ module Devise::Passwordless
             key: resource.to_key,
             email: resource.email,
           },
+          path: opts[:path],
         },
         created_at: now.to_f,
       })

--- a/lib/devise/strategies/magic_link_authenticatable.rb
+++ b/lib/devise/strategies/magic_link_authenticatable.rb
@@ -42,6 +42,7 @@ module Devise
         if validate(resource)
           remember_me(resource)
           resource.after_magic_link_authentication
+          set_return_to_path(data["path"])
           success!(resource)
         else
           fail!(:magic_link_invalid)
@@ -61,6 +62,10 @@ module Devise
 
         parse_authentication_key_values(auth_values, authentication_keys) &&
         parse_authentication_key_values(request_values, request_keys)
+      end
+
+      def set_return_to_path(path)
+        path.present? && session["#{scope}_return_to"] = path
       end
     end
   end


### PR DESCRIPTION
In order to allow magic links to send the user to a specific path on the site, include an optional `path` parameter when encoding the token. This allows us to include the path in the payload where it can't be altered by the client.