### PR TITLE
Auto-refresh stale login links

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ config.mailer = "Devise::Passwordless::Mailer"
 # generated before the user's current sign in time to be expired. In other words,
 # each time you sign in, all existing magic links will be considered invalid.
 # config.passwordless_expire_old_tokens_on_sign_in = false
+
+# If a user visits via an expired login_link, automatically
+# send them a fresh login link.
+# config.passwordless_auto_refresh_expired_login_links = false
 ```
 
 To customize the magic link email subject line and other status and error messages, modify these values in `config/locales/devise.en.yml`:

--- a/lib/devise/models/magic_link_authenticatable.rb
+++ b/lib/devise/models/magic_link_authenticatable.rb
@@ -46,7 +46,8 @@ module Devise
         Devise::Models.config(self,
           :passwordless_login_within,
           :passwordless_secret_key,
-          :passwordless_expire_old_tokens_on_sign_in
+          :passwordless_expire_old_tokens_on_sign_in,
+          :passwordless_auto_refresh_expired_login_links
         )
       end
     end
@@ -62,4 +63,7 @@ module Devise
 
   mattr_accessor :passwordless_expire_old_tokens_on_sign_in
   @@passwordless_expire_old_tokens_on_sign_in = false
+
+  mattr_accessor :passwordless_auto_refresh_expired_login_links
+  @@passwordless_auto_refresh_expired_login_links = false
 end

--- a/lib/devise/passwordless/login_token.rb
+++ b/lib/devise/passwordless/login_token.rb
@@ -1,6 +1,7 @@
 module Devise::Passwordless
   class LoginToken
     class InvalidOrExpiredTokenError < StandardError; end
+    class ExpiredTokenError < InvalidOrExpiredTokenError; end
 
     def self.encode(resource, extra=nil)
       now = Time.current
@@ -42,7 +43,7 @@ module Devise::Passwordless
 
       created_at = ActiveSupport::TimeZone["UTC"].at(decrypted_data["created_at"])
       if as_of.to_f > (created_at + expire_duration).to_f
-        raise InvalidOrExpiredTokenError
+        raise ExpiredTokenError
       end
 
       decrypted_data

--- a/lib/generators/devise/passwordless/install_generator.rb
+++ b/lib/generators/devise/passwordless/install_generator.rb
@@ -41,6 +41,10 @@ module Devise::Passwordless
           # generated before the user's current sign in time to be expired. In other words,
           # each time you sign in, all existing magic links will be considered invalid.
           # config.passwordless_expire_old_tokens_on_sign_in = false
+
+          # If a user visits via an expired login_link, automatically
+          # send them a fresh login link.
+          # config.passwordless_auto_refresh_expired_login_links = false
         CONFIG
         end
       end
@@ -78,6 +82,7 @@ module Devise::Passwordless
               },
               failure: {
                 magic_link_invalid: "Invalid or expired login link.",
+                magic_link_refresh: "Your login link has expired, please check your email for a new login link."
               },
               mailer: {
                 magic_link: {

--- a/spec/dummy_app/config/initializers/devise.rb
+++ b/spec/dummy_app/config/initializers/devise.rb
@@ -328,4 +328,8 @@ Devise.setup do |config|
   # generated before the user's current sign in time to be expired. In other words,
   # each time you sign in, all existing magic links will be considered invalid.
   # config.passwordless_expire_old_tokens_on_sign_in = false
+
+  # If a user visits via an expired login_link, automatically
+  # send them a fresh login link.
+  # config.passwordless_auto_refresh_expired_login_links = false
 end

--- a/spec/generators/templates/expected/devise.en.yml
+++ b/spec/generators/templates/expected/devise.en.yml
@@ -16,6 +16,7 @@ en:
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
       magic_link_invalid: "Invalid or expired login link."
+      magic_link_refresh: "Your login link has expired, please check your email for a new login link."
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"

--- a/spec/generators/templates/expected/devise.rb
+++ b/spec/generators/templates/expected/devise.rb
@@ -328,4 +328,8 @@ Devise.setup do |config|
   # generated before the user's current sign in time to be expired. In other words,
   # each time you sign in, all existing magic links will be considered invalid.
   # config.passwordless_expire_old_tokens_on_sign_in = false
+
+  # If a user visits via an expired login_link, automatically
+  # send them a fresh login link.
+  # config.passwordless_auto_refresh_expired_login_links = false
 end


### PR DESCRIPTION
Add a config var to enable a new behavior: when a user visits via a login link that is stale, the application will send a fresh link to the user.